### PR TITLE
OPENTOK-49765: fix missing captions UI in meet

### DIFF
--- a/opentok-angular.js
+++ b/opentok-angular.js
@@ -268,7 +268,7 @@ ng.module('opentok', [])
               // TODO ADD A BUTTON
               subscriber.subscribeToCaptions(true);
             },
-            captionsReceived: function (event) {
+            captionReceived: function (event) {
               captionEventHandler(event, subscriber)
             }
           });


### PR DESCRIPTION
For context, the event was renamed from `captionsReceived` to `captionReceived`. Opentok-Angular was not updated along with the other repos, causing captions in meet to break. This PR includes all PRs from the previous target: https://github.com/maikthomas/opentok-angular.git#add-init-session-options.

To test: 

- Set the apiKey to 47371301 in opentok-meet config.js. Ping me for the secret. 
- Point opentok-angular to https://github.com/michaelwhittemore/OpenTok-Angular.git#OPENTOK-49765-fix-meet-captions
- Run `npm install` and `npm run build`
- Run meet locally. 
- Start a session with a moderator token
- Publish in one tab and subscribe in another
- Click on the "transcribe" button.
- After a few seconds you should see captions on the subscriber widget
