### PR TITLE
VIDSCS-47: stop stream overlay should go away when stopping a ScreenToCanvas publisher

### DIFF
--- a/opentok-angular.js
+++ b/opentok-angular.js
@@ -147,7 +147,7 @@ ng.module('opentok', [])
             props.videoContentHint = 'detail';
             publisherVideo = document.createElement('video');
             navigator.mediaDevices.getDisplayMedia({ video: { width, height }, audio: false }).then((stream) => {
-              scope.streamForCanvas = stream.getTracks()
+              scope.canvasStreamTracks = stream.getTracks()
               stream.getTracks().forEach((track) => {
                 track.addEventListener('ended', () => {
                   if (scope.publisher) {
@@ -197,8 +197,8 @@ ng.module('opentok', [])
               scope.$emit('otAccessAllowed');
             },
             destroyed : function (e) {
-              if (scope.streamForCanvas){
-                scope.streamForCanvas.forEach(track => track.stop())
+              if (scope.canvasStreamTracks){
+                scope.canvasStreamTracks.forEach(track => track.stop())
               }
             },
             loaded: function () {

--- a/opentok-angular.js
+++ b/opentok-angular.js
@@ -147,7 +147,7 @@ ng.module('opentok', [])
             props.videoContentHint = 'detail';
             publisherVideo = document.createElement('video');
             navigator.mediaDevices.getDisplayMedia({ video: { width, height }, audio: false }).then((stream) => {
-              scope.GDMStream = stream.getTracks()
+              scope.streamForCanvas = stream.getTracks()
               stream.getTracks().forEach((track) => {
                 track.addEventListener('ended', () => {
                   if (scope.publisher) {
@@ -197,8 +197,8 @@ ng.module('opentok', [])
               scope.$emit('otAccessAllowed');
             },
             destroyed : function (e) {
-              if (scope.GDMStream){
-                scope.GDMStream.forEach(track => track.stop())
+              if (scope.streamForCanvas){
+                scope.streamForCanvas.forEach(track => track.stop())
               }
             },
             loaded: function () {

--- a/opentok-angular.js
+++ b/opentok-angular.js
@@ -147,6 +147,7 @@ ng.module('opentok', [])
             props.videoContentHint = 'detail';
             publisherVideo = document.createElement('video');
             navigator.mediaDevices.getDisplayMedia({ video: { width, height }, audio: false }).then((stream) => {
+              scope.GDMStream = stream.getTracks()
               stream.getTracks().forEach((track) => {
                 track.addEventListener('ended', () => {
                   if (scope.publisher) {
@@ -194,6 +195,11 @@ ng.module('opentok', [])
             accessAllowed: function () {
               ng.element(element).addClass('allowed');
               scope.$emit('otAccessAllowed');
+            },
+            destroyed : function (e) {
+              if (scope.GDMStream){
+                scope.GDMStream.forEach(track => track.stop())
+              }
             },
             loaded: function () {
               $rootScope.$broadcast('otLayout');


### PR DESCRIPTION
The "stop sharing" overlay doesn't go away when you stop a ScreenToCanvas publisher. This is because we were making a GDM request but never stopping the actual tracks we got from this call. 

To test: 
To reproduce:

-  Run meet locally 
-  Press the screenshareCanvas button and select a tab. See that a stop screenshare overlay appears at the bottom of your screen as in the image.
<img width="472" alt="Screenshot 2023-06-13 at 5 39 44 PM" src="https://github.com/Vonage/OpenTok-Angular/assets/35385066/dd2350a3-d4cb-406f-bca2-32f068ff9c91">
- Press the screenshareCanvas button again. Note that the publisher goes away but the overlay doesn't. 

To test the fix: 
- Copy the content of opentok-angular.js to the same file in your local meet node-modules.
- Repeat the above steps and verify that the overlay does go away when stopping the screenshareCanvas publisher.
