### PR TITLE
VIDCS-1969: Add subscriber resolution API to meet (enabled by default)

### DIFF
--- a/opentok-angular.js
+++ b/opentok-angular.js
@@ -255,6 +255,7 @@ ng.module('opentok', [])
             props = scope.props() || {};
           props.width = props.width ? props.width : ng.element(element).width();
           props.height = props.height ? props.height : ng.element(element).height();
+          props.preferredResolution = 'auto';
           var oldChildren = ng.element(element).children();
           var subscriber = OTSession.session.subscribe(stream, element[0], props, function (err) {
             if (err) {


### PR DESCRIPTION
This change is needed to be able to use `preferredResolution` as `auto` in `opentok-meet.`